### PR TITLE
Allow equality checks on output of `@htl`

### DIFF
--- a/docs/src/primitives.md
+++ b/docs/src/primitives.md
@@ -4,7 +4,7 @@ This is a regression test for components upon which HTL is constructed,
 the design centers around `EscapeProxy` which escapes content printed to
 it. There are several wrappers which drive special proxy handling.
 
-    using HypertextLiteral: EscapeProxy, Bypass, Reprint, Render
+    using HypertextLiteral: EscapeProxy, Bypass, Reprint, PrintSequence, Render
 
 ## EscapeProxy
 
@@ -47,6 +47,14 @@ Reprinted content is still subject to escaping.
 
     @echo print(ep, Reprint(io -> print(io, "(&'<\")")))
     #-> (&amp;&apos;&lt;&quot;)
+
+## PrintSequence
+
+This wrapper prints each of its contents. Unlike `Bypass`, escaping is still applied.
+
+    @echo print(ep, PrintSequence("hello ", Bypass("<tagged/>"), " <A&B>"))
+    #-> hello <tagged/> &lt;A&amp;B>
+
 
 ## Render
 

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -62,7 +62,7 @@ attribute_value(x::String) = x
 attribute_value(x::Number) = x
 attribute_value(x::Symbol) = x
 
-mutable struct AttributeValue
+struct AttributeValue
     content::Any
 end
 

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -164,10 +164,11 @@ function inside_tag(value::Union{AbstractString, Symbol})
 end
 
 function inside_tag(xs::AbstractDict)
-    PrintSequence(Iterators.map(xs) do (key,value)
-        name = normalize_attribute_name(key)
-        attribute_pair(name, value)
-    end...)
+    PrintSequence((
+        let name = normalize_attribute_name(key)
+            attribute_pair(name, value)
+        end for (key, value) in xs)...
+    )
 end
 
 inside_tag(values::NamedTuple) =

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -164,11 +164,10 @@ function inside_tag(value::Union{AbstractString, Symbol})
 end
 
 function inside_tag(xs::AbstractDict)
-    PrintSequence((
-        let name = normalize_attribute_name(key)
-            attribute_pair(name, value)
-        end for (key, value) in xs)...
-    )
+    PrintSequence(Iterators.map(xs) do (key,value)
+        name = normalize_attribute_name(key)
+        attribute_pair(name, value)
+    end...)
 end
 
 inside_tag(values::NamedTuple) =

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -96,29 +96,19 @@ macro htl_str(expr::String)
 end
 
 """
-    Result(fn)
+    Result(xs...)
 
-This object wraps a function produced by the `@htl` macro. This function
-prints a the evaluated to the given `io`. This object is also showable
-via `"text/html"` so it may be used in an HTML display context.
+This object wraps a sequence of objects produced by the `@htl` macro, 
+which are printed when the object is printed. This object is also 
+showable via `"text/html"` so it may be used in an HTML display context.
 """
 struct Result
-    content::Function
+    contents::Tuple
 
-    Result(fn::Function) = new(fn)
+    Result(contents...) = new(contents)
 end
 
-Result(ob) = Result(io::IO -> print(io, ob))
-
-function Result(xs...)
-    Result() do io::IO
-        for x in xs
-            print(io, x)
-        end
-    end
-end
-
-Base.show(io::IO, h::Result) = h.content(EscapeProxy(io))
-Base.show(io::IO, m::MIME"text/html", h::Result) = h.content(EscapeProxy(io))
-Base.show(io::EscapeProxy, h::Result) = h.content(io)
-Base.show(io::EscapeProxy, m::MIME"text/html", h::Result) = h.content(io)
+Base.show(io::EscapeProxy, h::Result) = print(io, h.contents...)
+Base.show(io::EscapeProxy, m::MIME"text/html", h::Result) = show(io, h)
+Base.show(io::IO, h::Result) = show(EscapeProxy(io), h)
+Base.show(io::IO, m::MIME"text/html", h::Result) = show(EscapeProxy(io), h)

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -1,7 +1,7 @@
 """
     Reprint(fn) - apply the lambda function when printed
 """
-mutable struct Reprint
+struct Reprint
     content::Function
 end
 
@@ -31,7 +31,7 @@ Base.print(io::IO, r::Render) =
     Bypass(data) - printed object passes though EscapeProxy unescaped
 """
 
-mutable struct Bypass{T}
+struct Bypass{T}
     content::T
 end
 

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -8,6 +8,16 @@ end
 Base.print(io::IO, r::Reprint) = r.content(io)
 
 """
+    PrintSequence(xs...) - print each contained object when printed
+"""
+struct PrintSequence
+    contents::Tuple
+
+    PrintSequence(contents...) = new(contents)
+end
+Base.print(io::IO, r::PrintSequence) = print(io, r.contents...)
+
+"""
     Render(data) - printed object shows its text/html
 """
 struct Render{T}

--- a/src/script.jl
+++ b/src/script.jl
@@ -38,7 +38,7 @@ Base.print(ep::EscapeProxy, x::ScriptTag) =
 
 This object renders Javascript `data` escaped within an attribute.
 """
-mutable struct Script
+struct Script
     content::Any
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,9 +55,9 @@ default = package_path.(["README.md", "docs/src"])
             quote
                 using HypertextLiteral:
                     HypertextLiteral, @htl, @htl_str,
-                    Reprint, Render, Bypass, EscapeProxy,
-                    attribute_value, content, attribute_pair,
-                    inside_tag
+                    Reprint, PrintSequence, Render, Bypass, 
+                    EscapeProxy, attribute_value, content, 
+                    attribute_pair, inside_tag
                 using Dates
             end)
         with_logger(Logging.ConsoleLogger(stderr, Logging.Warn)) do

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,7 +45,24 @@ ENV["COLUMNS"] = "72"
 package_path(x) = relpath(joinpath(dirname(abspath(PROGRAM_FILE)), "..", x))
 default = package_path.(["README.md", "docs/src"])
 
+macro htl_equality(expr)
+    htl_ex() = Expr(:macrocall, getfield(HypertextLiteral, Symbol("@htl")), __source__, deepcopy(expr))
+    :($(esc(htl_ex())) === $(esc(htl_ex())))
+end
+
 @testset "HypertextLiteral" begin
+    
+    @testset "Equality tests" begin
+        @info "Running equality tests..."
+        
+        @test @htl_equality "hello"
+        @test @htl_equality "hello $(123) world"
+        @test !@htl_equality "hello $(rand())"
+        @test !@htl_equality "hello $(Dict(:a => 1))"
+        @test @htl_equality "<div style=$((a=1,b=2))>a</div>"
+        @test @htl_equality "<div $((a=1,b=2))>a</div>"
+        @test @htl_equality "<script>let x = $((a=1,b=2));</script>"
+    end
 
     if isempty(ARGS) || "doctest" in ARGS
         @info "Running doctest..."


### PR DESCRIPTION
Currently, the following all evaluate to false:

```julia
@htl("hello") == @htl("hello")
@htl("hello") === @htl("hello")
@htl("<span>$(1 + 1)</span>") == @htl("<span>$(1 + 1)</span>")
```

And it would be nice if they evaluated to `true`! This would let us do things like skipping a re-render if the content is unchanged. Or my more specific application: in https://github.com/JuliaPluto/PlutoUI.jl/pull/163 , I want to persist the value of a bond if the rendered content was unchanged, and `@htl` is very likely to be the rendered content.

# Implementation

This PR does two things to make this work:
- Use `struct` instead of `mutable struct` wherever possible. Mutable structs have `===` and `==` equality defined based purely on their values. 21951fe8949dea119dc9f6bffd2d282083a7db19
- I avoid creating anonymous functions with closure wherever possible, and create a new struct instead. 05d0aac72499916ae1f0dc90ff1d82da8df0e2d9 and 4ae9e95dd6bc4fe0edab09dca0247b8bd7233912



# Tests

Tests are added in b7a24444ab50feaf09106deab3b932172ec27592 though I wasn't sure about the format. I did not include these in the narrative tests, because they are not really part of the HTL "narrative", nor the docs.