### PR TITLE
Make IO Context available inside `<script>`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## v0.9.4
+
+- Pull #27: Make IO Context available inside `<script>`
+
 ## v0.9.3
 
 - Pull #18: Interpolating within a paired tags

--- a/docs/src/attribute.md
+++ b/docs/src/attribute.md
@@ -125,7 +125,7 @@ desirable for use inside an attribute value.
     struct Custom data::String end
 
     @htl "<tag att=$(Custom("A&B"))/>"
-    #-> <tag att='…Custom(&quot;A&amp;B&quot;)'/>
+    #-> <tag att='Custom(&quot;A&amp;B&quot;)'/>
 
 This can be sometimes addressed by implementing `Base.print()`.
 

--- a/docs/src/primitives.md
+++ b/docs/src/primitives.md
@@ -10,11 +10,12 @@ it. There are several wrappers which drive special proxy handling.
 
 This utility class acts wraps an `IO` stream to provide HTML escaping.
 
-    io = IOBuffer()
+    io_buffer = IOBuffer()
+    io = IOContext(io_buffer, :hello => "world")
     ep = EscapeProxy(io)
 
     macro echo(expr)
-        :($expr; print(String(take!(io))))
+        :($expr; print(String(take!(io_buffer))))
     end
 
 The result of this proxy is that regular content printed to it is passed
@@ -23,6 +24,11 @@ along to the wrapped `IO`, after escaping the ampersand (`&`), less-than
 
     @echo print(ep, "(&'<\")")
     #-> (&amp;&apos;&lt;&quot;)
+
+Any [IO context properties](https://docs.julialang.org/en/v1/base/io-network/#Base.IOContext-Tuple{IO,%20Pair}) will be reflected by the `EscapeProxy`:
+
+    @echo print(ep, get(ep, :hello, "oops"))
+    #-> world
 
 ## Bypass
 

--- a/docs/src/script.md
+++ b/docs/src/script.md
@@ -149,24 +149,6 @@ this function on datatypes which require further translation.
 This method is how we provide support for datatypes in `Base` without
 committing type piracy by implementing `show` for `"text/javascript"`.
 
-### IO Context
-
-Any [IO context properties](https://docs.julialang.org/en/v1/base/io-network/#Base.IOContext-Tuple{IO,%20Pair}) of the renderer can be used, as expected:
-
-    struct Hello end
-    
-    function Base.show(io::IO, ::MIME"text/javascript", ::Hello)
-        print(io, get(io, :hello, "oops"))
-    end
-    
-    h = @htl("""<script>const x = $(Hello())</script>""")
-    
-    repr(
-        MIME"text/html"(), h; 
-        context=(:hello => "world")
-    )
-    #-> "<script>const x = world</script>"
-
 ## Edge Cases
 
 Within a `<script>` tag, comment start (`<!--`) must also be escaped.
@@ -185,3 +167,21 @@ It's important to handle unicode content properly.
 
     @htl("<script>alert($(s))</script>")
     #-> <script>alert("α\n")</script>
+
+## Regression tests
+
+Any [IO context properties](https://docs.julialang.org/en/v1/base/io-network/#Base.IOContext-Tuple{IO,%20Pair}) of the renderer can be used, as expected:
+
+    struct Hello end
+    
+    function Base.show(io::IO, ::MIME"text/javascript", ::Hello)
+        print(io, get(io, :hello, "oops"))
+    end
+    
+    h = @htl("""<script>const x = $(Hello())</script>""")
+    
+    repr(
+        MIME"text/html"(), h; 
+        context=(:hello => "world")
+    )
+    #-> "<script>const x = world</script>"

--- a/docs/src/script.md
+++ b/docs/src/script.md
@@ -149,6 +149,24 @@ this function on datatypes which require further translation.
 This method is how we provide support for datatypes in `Base` without
 committing type piracy by implementing `show` for `"text/javascript"`.
 
+### IO Context
+
+Any [IO context properties](https://docs.julialang.org/en/v1/base/io-network/#Base.IOContext-Tuple{IO,%20Pair}) of the renderer can be used, as expected:
+
+    struct Hello end
+    
+    function Base.show(io::IO, ::MIME"text/javascript", ::Hello)
+        print(io, get(io, :hello, "oops"))
+    end
+    
+    h = @htl("""<script>const x = $(Hello())</script>""")
+    
+    repr(
+        MIME"text/html"(), h; 
+        context=(:hello => "world")
+    )
+    #-> "<script>const x = world</script>"
+
 ## Edge Cases
 
 Within a `<script>` tag, comment start (`<!--`) must also be escaped.

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -27,6 +27,8 @@ end
 
 Base.print(io::IO, x::Bypass) = print(io, x.content)
 
+abstract type IOProxy <: IO end
+
 """
     EscapeProxy(io) - wrap an `io` to perform HTML escaping
 
@@ -44,7 +46,7 @@ julia> print(ep, Bypass("<tag/>"))
 <tag/>
 ```
 """
-struct EscapeProxy{T<:IO} <: IO
+struct EscapeProxy{T<:IO} <: IOProxy
     io::T
 end
 
@@ -108,3 +110,11 @@ function Base.unsafe_write(ep::EscapeProxy, input::Ptr{UInt8}, nbytes::UInt)
     end
     return written
 end
+
+# IO passthrough methods:
+Base.in(key_value::Pair, io::IOProxy) = in(key_value, io.io)
+Base.haskey(io::IOProxy, key) = haskey(io.io, key)
+Base.getindex(io::IOProxy, key) = getindex(io.io, key)
+Base.get(io::IOProxy, key, default) = get(io.io, key, default)
+Base.keys(io::IOProxy) = keys(io.io)
+Base.displaysize(io::IOProxy) = displaysize(io.io)

--- a/src/script.jl
+++ b/src/script.jl
@@ -13,7 +13,7 @@ julia> print(gp, "</script>")
 ERROR: "Content within a script tag must not contain `</script>`"
 ```
 """
-mutable struct ScriptTagProxy{T<:IO} <: IO where {T}
+mutable struct ScriptTagProxy{T<:IO} <: IOProxy where {T}
     io::T
     index::Int
 

--- a/src/style.jl
+++ b/src/style.jl
@@ -13,7 +13,7 @@ julia> print(gp, "</style>")
 ERROR: "Content within a style tag must not contain `</style>`"
 ```
 """
-mutable struct StyleTagProxy{T<:IO} <: IO where {T}
+mutable struct StyleTagProxy{T<:IO} <: IOProxy where {T}
     io::T
     index::Int
 


### PR DESCRIPTION
This PR makes it possible to use `get(io, :key, "default")` inside custom show methods to query the [io context](https://docs.julialang.org/en/v1/base/io-network/#Base.IOContext-Tuple{IO,%20Pair}) of the renderer. This already worked for objects interpolated inside HTML, because this rendering is not proxied, but not for objects interpolated inside `<script>`.

```julia
struct Hello end

function Base.show(io::IO, ::MIME"text/javascript", ::Hello)
    print(io, get(io, :hello, "oops"))
end

h = @htl("""<script>const x = $(Hello())</script>""")

repr(
    MIME"text/html"(), h; 
    context=(:hello => "world")
)
#-> "<script>const x = world</script>"
```
