### PR TITLE
Make `content` automatically recompile if users define a html overload to `show`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ authors = ["Clark C. Evans <cce@clarkevans.com>"]
 version = "0.9.3"
 
 [compat]
-julia = "1.3"
+julia = "1"
 Tricks = "0.1.6"
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,11 @@ authors = ["Clark C. Evans <cce@clarkevans.com>"]
 version = "0.9.3"
 
 [compat]
-julia = "1"
+julia = "1.3"
+Tricks = "0.1.6"
+
+[deps]
+Tricks = "410a4b4d-49e4-4fbc-ab6d-cb71b17b3775"
 
 [extras]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/HypertextLiteral.jl
+++ b/src/HypertextLiteral.jl
@@ -32,7 +32,9 @@ See also: [`@htl`](@ref), [`HypertextLiteral.@htl_str`](@ref)
 """
 module HypertextLiteral
 
-using Tricks: static_hasmethod
+@static if VERSION >= v"1.3"
+    using Tricks: static_hasmethod
+end
 
 export @htl, @htl_str
 

--- a/src/HypertextLiteral.jl
+++ b/src/HypertextLiteral.jl
@@ -32,6 +32,8 @@ See also: [`@htl`](@ref), [`HypertextLiteral.@htl_str`](@ref)
 """
 module HypertextLiteral
 
+using Tricks: static_hasmethod
+
 export @htl, @htl_str
 
 include("primitives.jl") # Wrap, Unwrap, EscapeProxy

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -84,17 +84,17 @@ used. Otherwise, the result is printed within a `<span>` tag, using a
 `class` that includes the module and type name. Hence, `missing` is
 serialized as: `<span class="Base-Missing">missing</span>`.
 """
-@generated function content(x)
-     if hasmethod(show, Tuple{IO, MIME{Symbol("text/html")}, x})
-         return :(Render(x))
+function content(x::T) where {T}
+     if static_hasmethod(show, Tuple{IO, MIME{Symbol("text/html")}, T})
+         return Render(x)
      else
-         mod = parentmodule(x)
-         cls = string(nameof(x))
+         mod = parentmodule(T)
+         cls = string(nameof(T))
          if mod == Core || mod == Base || pathof(mod) !== nothing
              cls = join(fullname(mod), "-") * "-" * cls
          end
          span = """<span class="$cls">"""
-         return :(reprint(Bypass($span), x, Bypass("</span>")))
+         return reprint(Bypass(span), x, Bypass("</span>"))
      end
 end
 

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -71,7 +71,8 @@ Base.print(ep::EscapeProxy, x::AttributeValue) =
 
 attribute_value(@nospecialize x) = AttributeValue(x)
 
-"""
+function content end
+@doc """
     content(x)
 
 This method may be implemented to specify a printed representation
@@ -83,19 +84,36 @@ implemented a way to show themselves as `text/html`, if so, this is
 used. Otherwise, the result is printed within a `<span>` tag, using a
 `class` that includes the module and type name. Hence, `missing` is
 serialized as: `<span class="Base-Missing">missing</span>`.
-"""
-function content(x::T) where {T}
-     if static_hasmethod(show, Tuple{IO, MIME{Symbol("text/html")}, T})
-         return Render(x)
-     else
-         mod = parentmodule(T)
-         cls = string(nameof(T))
-         if mod == Core || mod == Base || pathof(mod) !== nothing
-             cls = join(fullname(mod), "-") * "-" * cls
-         end
-         span = """<span class="$cls">"""
-         return reprint(Bypass(span), x, Bypass("</span>"))
-     end
+""" content
+
+@static if VERSION >= v"1.3"
+    function content(x::T) where {T}
+        if static_hasmethod(show, Tuple{IO, MIME{Symbol("text/html")}, T})
+            return Render(x)
+        else
+            mod = parentmodule(T)
+            cls = string(nameof(T))
+            if mod == Core || mod == Base || pathof(mod) !== nothing
+                cls = join(fullname(mod), "-") * "-" * cls
+            end
+            span = """<span class="$cls">"""
+            return reprint(Bypass(span), x, Bypass("</span>"))
+        end
+    end
+else
+    @generated function content(x)
+        if hasmethod(show, Tuple{IO, MIME{Symbol("text/html")}, x})
+            return :(Render(x))
+        else
+            mod = parentmodule(x)
+            cls = string(nameof(x))
+            if mod == Core || mod == Base || pathof(mod) !== nothing
+                cls = join(fullname(mod), "-") * "-" * cls
+            end
+            span = """<span class="$cls">"""
+            return :(reprint(Bypass($span), x, Bypass("</span>")))
+        end
+    end
 end
 
 function reprint(xs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,14 +77,17 @@ default = package_path.(["README.md", "docs/src"])
     end
 end
 
-struct Foo end
+@static if VERSION >= v"1.3"
+    
+    struct Foo end
+    
+    @testset "invalidation" begin 
+        @test HypertextLiteral.content(Foo()) isa HypertextLiteral.Reprint # fallback
 
-@testset "invalidation" begin 
-    @test HypertextLiteral.content(Foo()) isa HypertextLiteral.Reprint # fallback
-    
-    # Now define a html printing type 
-    @eval Base.show(io::IO, ::MIME"text/html", ::Foo) = "Foo"
-    
-    # Previously this would not have worked because content is a generated function depending on hasmethod in the generator
-    @test repr(Base.invokelatest(HypertextLiteral.content, Foo())) == "HypertextLiteral.Render{Foo}(Foo())"
+        # Now define a html printing type 
+        @eval Base.show(io::IO, ::MIME"text/html", ::Foo) = "Foo"
+
+        # Previously this would not have worked because content is a generated function depending on hasmethod in the generator
+        @test repr(Base.invokelatest(HypertextLiteral.content, Foo())) == "HypertextLiteral.Render{Foo}(Foo())"
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -80,8 +80,11 @@ end
 struct Foo end
 
 @testset "invalidation" begin 
-    @test repr(HypertextLiteral.content(Foo())) == "HypertextLiteral.Reprint(HypertextLiteral.var\"#6#7\"{Tuple{HypertextLiteral.Bypass{String}, Foo, HypertextLiteral.Bypass{String}}}((HypertextLiteral.Bypass{String}(\"<span class=\\\"Foo\\\">\"), Foo(), HypertextLiteral.Bypass{String}(\"</span>\"))))"
+    @test HypertextLiteral.content(Foo()) isa HypertextLiteral.Reprint # fallback
+    
+    # Now define a html printing type 
     @eval Base.show(io::IO, ::MIME"text/html", ::Foo) = "Foo"
+    
     # Previously this would not have worked because content is a generated function depending on hasmethod in the generator
     @test repr(Base.invokelatest(HypertextLiteral.content, Foo())) == "HypertextLiteral.Render{Foo}(Foo())"
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -76,3 +76,12 @@ default = package_path.(["README.md", "docs/src"])
         end
     end
 end
+
+struct Foo end
+
+@testset "invalidation" begin 
+    @test repr(HypertextLiteral.content(Foo())) == "HypertextLiteral.Reprint(HypertextLiteral.var\"#6#7\"{Tuple{HypertextLiteral.Bypass{String}, Foo, HypertextLiteral.Bypass{String}}}((HypertextLiteral.Bypass{String}(\"<span class=\\\"Foo\\\">\"), Foo(), HypertextLiteral.Bypass{String}(\"</span>\"))))"
+    @eval Base.show(io::IO, ::MIME"text/html", ::Foo) = "Foo"
+    # Previously this would not have worked because content is a generated function depending on hasmethod in the generator
+    @test repr(Base.invokelatest(HypertextLiteral.content, Foo())) == "HypertextLiteral.Render{Foo}(Foo())"
+end


### PR DESCRIPTION
Closes https://github.com/JuliaPluto/HypertextLiteral.jl/issues/28

Before this PR:
```julia
julia> struct Foo end

julia> HypertextLiteral.content(Foo())
HypertextLiteral.Reprint(HypertextLiteral.var"#6#7"{Tuple{HypertextLiteral.Bypass{String}, Foo, HypertextLiteral.Bypass{String}}}((HypertextLiteral.Bypass{String}("<span class=\"Foo\">"), Foo(), HypertextLiteral.Bypass{String}("</span>"))))

julia> Base.show(io::IO, ::MIME"text/html", ::Foo) = "Foo"

julia> HypertextLiteral.content(Foo())
HypertextLiteral.Reprint(HypertextLiteral.var"#6#7"{Tuple{HypertextLiteral.Bypass{String}, Foo, HypertextLiteral.Bypass{String}}}((HypertextLiteral.Bypass{String}("<span class=\"Foo\">"), Foo(), HypertextLiteral.Bypass{String}("</span>"))))
```
After:
```julia
julia> struct Foo end

julia> HypertextLiteral.content(Foo())
HypertextLiteral.Reprint(HypertextLiteral.var"#6#7"{Tuple{HypertextLiteral.Bypass{String}, Foo, HypertextLiteral.Bypass{String}}}((HypertextLiteral.Bypass{String}("<span class=\"Foo\">"), Foo(), HypertextLiteral.Bypass{String}("</span>"))))

julia> Base.show(io::IO, ::MIME"text/html", ::Foo) = "Foo"

julia> HypertextLiteral.content(Foo())
HypertextLiteral.Render{Foo}(Foo())
```

This shouldn't come with any accompanying performance loss, at least in the case where the `show` method is used (the intended usecase from what I understand).  
```julia
julia> @code_typed HypertextLiteral.content(Foo())
CodeInfo(
1 ─     return $(QuoteNode(HypertextLiteral.Render{Foo}(Foo())))
) => HypertextLiteral.Render{Foo}
```
This is saying that the check to `static_hasmethod` has been compiled away, but due to the mechanism used by tricks, it knows to recompile if the old result gets invalidated. 

One downside though is that Tricks only supports versions 1.3 and up, so I have made it so that on those older versions, the old behaviour with the generated functions remains. Alternatively, we could just drop support for the old versions (since the LTS is now 1.6 afterall) or we could make the fallback an error on old versions.  