### PR TITLE
Fix print_script for 1.10

### DIFF
--- a/src/script.jl
+++ b/src/script.jl
@@ -95,14 +95,27 @@ The fallback behavior of `print_script` is to show the object as
 `"text/javascript"`. The `Javascript` wrapper will take any string
 and let it be printed in this way.
 """
-print_script(io::IO, value::Any) =
-    show(io, MIME"text/javascript"(), value)
+@static if VERSION > v"1.9.99"
+    # With the new JuliaSyntax parser, `hasmethod` appears to be invoked before
+    # other packages are loaded. 
+    print_script(io::IO, value::Any) =
+        show(io, MIME"text/javascript"(), value)
+else
+@generated function print_script(io::IO, value)
+     # workaround for Julia#18221
+     if hasmethod(show, Tuple{IO, MIME{Symbol("text/javascript")}, value})
+         return :(show(io, MIME"text/javascript"(), value))
+     end
+     throw("$(value) is not showable as text/javascript")
+end
+end
 print_script(io::IO, ::Nothing) =
     print(io, "undefined")
 print_script(io::IO, ::Missing) =
     print(io, "null")
 print_script(io::IO, value::Union{Bool, Symbol}) =
     print(io, value)
+
 
 function print_script(io::IO, value::Union{NamedTuple, AbstractDict})
     print(io, '{')

--- a/src/script.jl
+++ b/src/script.jl
@@ -95,13 +95,8 @@ The fallback behavior of `print_script` is to show the object as
 `"text/javascript"`. The `Javascript` wrapper will take any string
 and let it be printed in this way.
 """
-@generated function print_script(io::IO, value)
-     # workaround for Julia#18221
-     if hasmethod(show, Tuple{IO, MIME{Symbol("text/javascript")}, value})
-         return :(show(io, MIME"text/javascript"(), value))
-     end
-     throw("$(value) is not showable as text/javascript")
-end
+print_script(io::IO, value::Any) =
+    show(io, MIME"text/javascript"(), value)
 print_script(io::IO, ::Nothing) =
     print(io, "undefined")
 print_script(io::IO, ::Missing) =


### PR DESCRIPTION
Appearantly, at the time when @generated is evaluated, methods from other packages may not have been compiled yet, so
`hasmethod(show, Tuple{IO, MIME{Symbol("text/javascript")}, value})` returns false, and the @generated function print_script throws an error.

As the old version worked in 1.9.3, the different behavior appears to be the result of subtle changes in precompilation/initialization behavior somewhere between 1.9.3 and 1.10.0-beta2.