### PR TITLE
Cap documenter version to "0"

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,2 +1,5 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "0"


### PR DESCRIPTION
There seem to be breaking changes in Documenter 1.x regarding Documenter.Expanders and code block highlighting in docstrings.

This PR proposes to limit the Documenter version to <1.0 as a quick fix until there is time to figure out what has been changed.

Alternatively, we could suspend highlighting in docstrings.