### PR TITLE
Disable scheduled CI runs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,8 +5,6 @@ on:
   pull_request:
     branches: [ master ]
   workflow_dispatch:
-  schedule:
-  - cron: "0 9 * * *"
 jobs:
   test:
     if: ${{ false }}  # disable for now

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,6 @@ on:
   pull_request:
     branches: [ master ]
   workflow_dispatch:
-  schedule:
-  - cron: "0 9 * * 0"
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
It looks like GitHub disabled the two actions `release` and `nightly` (also for other events like `push`) because there was "no activity for 60 days", and you have to manually re-enable the action. That's why a commit like https://github.com/JuliaPluto/HypertextLiteral.jl/commit/5005d05206078f5cb6009d4c9f4741ff843511f0 does not have CI runs.

Since HypertextLiteral.jl is mostly *finished*, we don't plan to commit often. This will mean that the occasional PR/commit won't have CI runs because GH will disable the actions again. 

So in this PR I remove the `schedule` to prevent GitHub from disabling the action.