### PR TITLE
use Tricks.compat_has_method

### DIFF
--- a/src/HypertextLiteral.jl
+++ b/src/HypertextLiteral.jl
@@ -32,9 +32,7 @@ See also: [`@htl`](@ref), [`HypertextLiteral.@htl_str`](@ref)
 """
 module HypertextLiteral
 
-@static if VERSION >= v"1.3"
-    using Tricks: static_hasmethod
-end
+using Tricks: compat_hasmethod
 
 export @htl, @htl_str
 

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -86,35 +86,20 @@ used. Otherwise, the result is printed within a `<span>` tag, using a
 serialized as: `<span class="Base-Missing">missing</span>`.
 """ content
 
-@static if VERSION >= v"1.3"
-    function content(x::T) where {T}
-        if static_hasmethod(show, Tuple{IO, MIME{Symbol("text/html")}, T})
-            return Render(x)
-        else
-            mod = parentmodule(T)
-            cls = string(nameof(T))
-            if mod == Core || mod == Base || pathof(mod) !== nothing
-                cls = join(fullname(mod), "-") * "-" * cls
-            end
-            span = """<span class="$cls">"""
-            return reprint(Bypass(span), x, Bypass("</span>"))
+function content(x::T) where {T}
+    if compat_hasmethod(show, Tuple{IO, MIME{Symbol("text/html")}, T})
+        return Render(x)
+    else
+        mod = parentmodule(T)
+        cls = string(nameof(T))
+        if mod == Core || mod == Base || pathof(mod) !== nothing
+            cls = join(fullname(mod), "-") * "-" * cls
         end
-    end
-else
-    @generated function content(x)
-        if hasmethod(show, Tuple{IO, MIME{Symbol("text/html")}, x})
-            return :(Render(x))
-        else
-            mod = parentmodule(x)
-            cls = string(nameof(x))
-            if mod == Core || mod == Base || pathof(mod) !== nothing
-                cls = join(fullname(mod), "-") * "-" * cls
-            end
-            span = """<span class="$cls">"""
-            return :(reprint(Bypass($span), x, Bypass("</span>")))
-        end
+        span = """<span class="$cls">"""
+        return reprint(Bypass(span), x, Bypass("</span>"))
     end
 end
+
 
 function reprint(xs...)
     # generated functions cannot contain a closure


### PR DESCRIPTION
`compat_hasmethod` is `hasmethod` pre-julia 1.3, and `static_hasmethod` after.
It was added in Tricks v0.1.3, (and HyperTextLiterals.jl already required Tricks v0.1.6)

Technically this will cause a performance regression on julia 1.0-1.2,
since the old code used `hasmethod` insider a generated function.
But that was never sound, and would lead to incorrect behavour when new methods are added later interactively.
So this fixes those cases.